### PR TITLE
Update whitelist to require url matches exactly

### DIFF
--- a/lib/insecurity.js
+++ b/lib/insecurity.js
@@ -96,7 +96,7 @@ exports.redirectWhitelist = redirectWhitelist
 exports.isRedirectAllowed = url => {
   let allowed = false
   for (const allowedUrl of redirectWhitelist) {
-    allowed = allowed || url.includes(allowedUrl)
+    allowed = allowed || url.equals(allowedUrl)
   }
   return allowed
 }


### PR DESCRIPTION
Fix whitelist bypassing by requiring that the URL match exactly.

Username: Gavin.Nicol
Team: GavinNicol